### PR TITLE
longcallR-ase.py gene type patch

### DIFF
--- a/allele_specific/longcallR-ase.py
+++ b/allele_specific/longcallR-ase.py
@@ -119,7 +119,10 @@ def get_gene_regions(annotation_file, gene_types):
 
             if feature_type == "gene":
                 gene_id = attr_dict["gene_id"]
-                gene_type = attr_dict["gene_type"]
+                try:
+                    gene_type = attr_dict["gene_type"]
+                except KeyError:
+                    gene_type = attr_dict["gene_biotype"]
                 tag = attr_dict.get("tag", "")
                 try:
                     gene_name = attr_dict["gene_name"]

--- a/allele_specific/longcallR-ase.py
+++ b/allele_specific/longcallR-ase.py
@@ -131,7 +131,10 @@ def get_gene_regions(annotation_file, gene_types):
                 if gene_type in gene_types and "readthrough" not in tag:
                     process_gene(parts, gene_id, gene_name)
             elif feature_type == "exon":
-                gene_type = attr_dict["gene_type"]
+                try:
+                    gene_type = attr_dict["gene_type"]
+                except KeyError:
+                    gene_type = attr_dict["gene_biotype"]
                 transcript_id = attr_dict["transcript_id"]
                 gene_id = attr_dict["gene_id"]
                 tag = attr_dict.get("tag", "")


### PR DESCRIPTION
A simple try/except to avoid a keyError if an annotation file has a 'gene_biotype' field instead of a 'gene_type' field as in #10. Seemed the easiest way to go about it without having to move the dictionary assignments inside of the gff3 vs gtf file type conditional statements.